### PR TITLE
Adds initial support for cursors and immutable structures as input

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,12 +7,30 @@ var assign = require('lodash.assign');
 var elements = require('./elements');
 
 function createComponents(omniscient){
+  var scu = omniscient.shouldComponentUpdate;
   var components = {};
 
   elements.forEach(function(element){
     components[element] = omniscient(element, function(props, statics){
+      // Best approach to "magically" turn this to a child?
+      if (scu.isCursor(props) && !scu.isImmutable(props.deref())) {
+        props = {
+          children: props.deref()
+        };
+      }
+      else if (scu.isCursor(props)) {
+        props = props.deref();
+      }
+
+      if (scu.isImmutable(props)) {
+        props = props.toJS();
+      }
+
+      if (scu.isImmutable(statics)) {
+        statics = statics.toJS();
+      }
       var _props = assign({}, omit(props, 'statics'), statics);
-      return React.createElement(element, _props);
+      return React.createElement(element, _props)
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "code": "^1.3.0",
+    "immutable": "^3.6.2",
     "lab": "^5.2.1"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -5,6 +5,8 @@ var code = require('code');
 
 var React = require('react');
 var omniscient = require('omniscient');
+var Immutable = require('immutable');
+var Cursor = require('immutable/contrib/cursor');
 
 var components = require('../')(omniscient);
 
@@ -20,12 +22,52 @@ lab.experiment('components', function(){
     done();
   });
 
+  lab.test('works with cursors to scalars', function(done){
+    var data = Immutable.fromJS({ foo: 'myText' });
+    var cursor = Cursor.from(data, ['foo']);
+
+    var el = components.div(cursor);
+    var result = React.renderToString(el);
+    code.expect(result).to.contain('myText');
+    done();
+  });
+
+  lab.test('works with cursors to immutable structure', function(done){
+    var data = Immutable.fromJS({ className: 'my-class' });
+    var cursor = Cursor.from(data, []);
+
+    var el = components.div(cursor);
+    var result = React.renderToString(el);
+    code.expect(result).to.contain('class="my-class"');
+    done();
+  });
+
+  lab.test('works with immutable structure', function(done){
+    var data = Immutable.fromJS({ className: 'my-class' });
+
+    var el = components.div(data);
+    var result = React.renderToString(el);
+    code.expect(result).to.contain('class="my-class"');
+    done();
+  });
+
   lab.test('accepts statics', function(done){
     var el = components.button(props, statics);
     var result = React.renderToString(el);
     code.expect(result).to.contain('type="submit"');
     done();
   });
+
+
+  lab.test('works with immutable structure as statics', function(done){
+    var data = Immutable.fromJS({ className: 'my-class' });
+
+    var el = components.div({}, data);
+    var result = React.renderToString(el);
+    code.expect(result).to.contain('class="my-class"');
+    done();
+  });
+
 
   lab.test('does not mutate props or statics', function(done){
     var el = components.button(props, statics);


### PR DESCRIPTION
I don't know if the approach of adding potential scalar values as children is the best one, but it's a suggestion and opens for discussion.
